### PR TITLE
🐛 Fix the LICENSE file link

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -40,4 +40,4 @@ Depois que o merge da sua pull request for feito, você pode deletar a sua branc
 
 ## :memo: Licença
 
-Esse projeto está sob a licença MIT. Veja o arquivo [LICENSE](LICENSE.md) para mais detalhes.
+Esse projeto está sob a licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.


### PR DESCRIPTION
Remove the .md from the README License link to redirect to the correct file